### PR TITLE
PHP 7 apcu integration

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN set -x \
     php7-pdo_pgsql \
     php7-curl \
     php7-ftp \
+    php7-apcu \
   && rm -rf /var/cache/apk/* \
   && mkdir /tmp/nginx \
   && mkdir -p /var/www/html \


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] the containers are successfully running
- [ ] a test and/or benchmark is included
- [ ] documentation is changed or added

##### Description of change
<!-- provide a description of the change below this comment -->

Add support for PHP 7 apcu, as seen on:
https://www.drupal.org/node/2327507

To enable `php7-apcu` add these lines in `sites/default/settings.php`
```php
$settings['cache']['bootstrap'] = 'cache.backend.apcu';
$settings['cache']['config'] = 'cache.backend.apcu';
$settings['cache']['discovery'] = 'cache.backend.apcu';
```

Resolves: #48
Signed-off-by: Minca Daniel Andrei <mandrei17@gmail.com>