### PR TITLE
Add persistent db container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ restart:
 	docker-compose restart
 
 clean: clean-containers clean-images
-	sudo rm -rf app
+	sudo rm -rf app db
 
 clean-containers:
 	docker rm -v $$(docker ps -aq -f status=exited)
@@ -44,6 +44,7 @@ build-drupal:
 	cp $(DRUPAL_SITES)/default.services.yml $(DRUPAL_SITES)/services.yml
 	chmod 666 $(DRUPAL_SITES)/settings.php $(DRUPAL_SITES)/services.yml
 	mkdir $(DRUPAL_SITES)/files
+	mkdir db
 	chmod 777 $(DRUPAL_SITES)/files
 	# set permissions for the app folder
 	./conf.sh perms

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 # Drupal dev env based on Docker
 > Run Drupal **8.x.x** from Docker containers
 
+- :new: [Drupal Console][3] integrated
+- :new: Persistent PostgreSQL container
+
 ## Running the project
 
 * First, Drupal must be pulled from the web and configured
@@ -63,3 +66,4 @@ Made with :heart: for [drupal][2] developers.
 
 [1]: https://github.com/dminca/dockerized-drupal/wiki/References
 [2]: https://www.drupal.org/
+[3]: https://drupalconsole.com/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,7 @@ psql:
     - POSTGRES_PASSWORD=drupal
     - POSTGRES_USER=drupal
     - POSTGRES_DB=drupal
+  volumes:
+    - ./db:/var/lib/postgresql/data
   # ports:
   #   - "5432:5432"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements and walk
through the checklist. You can 'tick' a box by using the letter "x": [x].
-->

##### Checklist
<!-- remove lines that do not apply to you -->

- [x] the containers are successfully running
- [ ] a test and/or benchmark is included
- [x] documentation is changed or added

##### Description of change
<!-- provide a description of the change below this comment -->

If launched containers are stopped or wiped, db data is lost, therefore
throwing fatal PHP errors and making pages unable to render

As a result, make the db container persistent so that whenever the
containers are stopped/wiped nothing is lost